### PR TITLE
Changed synchroneous FSM behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*build
+*build-cross

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,15 +13,15 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Build type" FORCE)
 endif()
 
-add_library(Fsm INTERFACE)
-add_library(Fsm::Fsm ALIAS Fsm)
+add_library(fsm INTERFACE)
+add_library(fsm::fsm ALIAS fsm)
 
-target_include_directories(Fsm INTERFACE
+target_include_directories(fsm INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
 
-install(TARGETS Fsm EXPORT FsmTargets
+install(TARGETS fsm EXPORT FsmTargets
     INCLUDES DESTINATION include
 )
 
@@ -29,7 +29,7 @@ install(DIRECTORY include/ TYPE INCLUDE)
 
 install(EXPORT FsmTargets
     FILE FsmTargets.cmake
-    NAMESPACE Fsm::
+    NAMESPACE fsm::
     DESTINATION lib/cmake/fsm
 )
 

--- a/examples/light_switch/CMakeLists.txt
+++ b/examples/light_switch/CMakeLists.txt
@@ -5,7 +5,7 @@ add_executable(ls_async_pthread ls_async_pthread.cpp async_fsm.cpp)
 target_compile_features(ls_async_pthread PRIVATE cxx_std_14)
 
 target_link_libraries(ls_async_pthread PRIVATE
-    Fsm::Fsm
+    fsm::fsm
     Threads::Threads
 )
 
@@ -14,7 +14,7 @@ add_executable(ls_sync_posix ls_sync_posix.cpp sync_fsm.cpp)
 target_compile_features(ls_sync_posix PRIVATE cxx_std_14)
 
 target_link_libraries(ls_sync_posix PRIVATE
-    Fsm::Fsm
+    fsm::fsm
     Threads::Threads
 )
 
@@ -26,7 +26,7 @@ if(BUILD_EXAMPLES_WITH_FREERTOS_SUPPORT)
     target_compile_features(ls_async_freertos PRIVATE cxx_std_14)
 
     target_link_libraries(ls_async_freertos PRIVATE
-        Fsm::Fsm
+        fsm::fsm
         freertos
         Threads::Threads
     )

--- a/examples/light_switch/sync_fsm.cpp
+++ b/examples/light_switch/sync_fsm.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
 #include "sync_fsm.hpp"
 
 extern void set_brightness(int value);
@@ -82,6 +82,10 @@ FSM::MotionModeHierarchy::MotionModeHierarchy() {
 
     sd_mm_detect.entry = [this](FSMInitContextType& ctx) {
         set_brightness(3);
-        ctx.set_callback([this](FSMContextType& ctx) { ctx.submit_event(EventMotionDetectTimeout()); }, true, 3000);
+        ctx.set_next_timeout(3000);
+    };
+
+    sd_mm_detect.handler = [this](FSMContextType& ctx) {
+        ctx.submit_event(EventMotionDetectTimeout());
     };
 }

--- a/examples/light_switch/sync_fsm.hpp
+++ b/examples/light_switch/sync_fsm.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
 #ifndef SYNC_FSM_HPP
 #define SYNC_FSM_HPP
 
@@ -11,6 +11,7 @@ struct FSM {
     using EventInfoType = fsm::EventInfo<EventBaseType, EventBufferType>;
     using StateHandleType = fsm::sync::StateHandle<EventInfoType, StateIDType>;
     using FSMInitContextType = StateHandleType::FSMInitContextType;
+
     using FSMContextType = StateHandleType::FSMContextType;
     using TransitionType = StateHandleType::TransitionWrapperType;
 

--- a/include/fsm/fsm.hpp
+++ b/include/fsm/fsm.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
 #ifndef FSM_FSM_HPP
 #define FSM_FSM_HPP
 
@@ -92,7 +92,7 @@ public:
         }
     }
 
-private:
+protected:
     enum class WrapType : uint8_t
     {
         None,
@@ -102,9 +102,13 @@ private:
         CtxFnWithoutEvent,
         MemFnWithEvent,
         MemFnWithoutEvent,
-        InstRetVal
+        InstRetVal,
+        Internal
     };
 
+    WrapType wrap_type{WrapType::None};
+
+private:
     template <typename ED, R (*fn)(const ED&)> static R fn_tramp(void* buf) {
         return (*fn)(*reinterpret_cast<ED*>(buf));
     }
@@ -123,9 +127,7 @@ private:
         return (cast_class_inst->*mem_fn)();
     }
 
-    WrapType wrap_type{WrapType::None};
-
-    R (*fn_ptr)(){nullptr};
+        R (*fn_ptr)(){nullptr};
     R (*fn_v_ptr)(void*){nullptr};
     R (*fn_v_v_ptr)(void*, void*){nullptr};
 

--- a/include/fsm/sync.hpp
+++ b/include/fsm/sync.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
 #ifndef FSM_SYNC_HPP
 #define FSM_SYNC_HPP
 
@@ -11,114 +11,69 @@
 namespace fsm {
 namespace sync {
 
-template <typename EventBaseType> class FSMContext;
-
-template <typename EventBaseType> class FSMInitContext {
+class FSMCommonContext {
 public:
-    virtual void set_callback(utils::StaticThisFunctor<void(FSMContext<EventBaseType>&)> fn, bool single_shot,
-                              int interval) = 0;
+    virtual void set_next_timeout(int interval, bool repeat = false) = 0;
 };
 
-template <typename EventBaseType> class FSMContext : public FSMInitContext<EventBaseType> {
+template <typename EventBaseType> class FSMInitContext : virtual public FSMCommonContext {
+public:
+    // FIXME (aw): internal events can't be forwarded directly
+    // and would need to be stored, but we don't have their type
+    // ..., only possible if we template this submit function
+    // const EventBaseType& ev() {
+    //     return event;
+    // }
+
+protected:
+    // const EventBaseType* event;
+};
+
+template <typename EventBaseType> class FSMContext : virtual public FSMCommonContext {
 public:
     virtual bool submit_event(const EventBaseType& ev) = 0;
-    virtual void cancel_callback() = 0;
-    virtual void repeat_callback() = 0;
+    virtual void disable_timeout() = 0;
     virtual ~FSMContext() = default; // FIXME (aw): is this necessary when only pass it as a reference?
+};
+
+template <typename R, typename EventInfoType> class SyncTransitionWrapper : public TransitionWrapper<R, EventInfoType> {
+public:
+    using FSMContextType = FSMContext<typename EventInfoType::BaseType>;
+    explicit SyncTransitionWrapper(FSMContextType& state_ctx) : state_ctx(state_ctx){};
+
+    FSMContextType& set_internal() {
+        // FIXME (aw): howto shorten this type?
+        this->wrap_type = TransitionWrapper<R, EventInfoType>::WrapType::Internal;
+        return state_ctx;
+    }
+
+    bool is_internal() {
+        return (this->wrap_type == TransitionWrapper<R, EventInfoType>::WrapType::Internal);
+    }
+
+private:
+    FSMContextType& state_ctx;
 };
 
 template <typename EventInfoType, typename StateIDType> struct StateHandle {
     StateHandle(const StateIDType& id) : id(id){};
-    using TransitionWrapperType = TransitionWrapper<StateHandle&, EventInfoType>;
+    using TransitionWrapperType = SyncTransitionWrapper<StateHandle&, EventInfoType>;
     using EventBaseType = typename EventInfoType::BaseType;
-    using FSMInitContextType = FSMInitContext<EventBaseType>;
     using FSMContextType = FSMContext<EventBaseType>;
-
+    using FSMInitContextType = FSMInitContext<EventBaseType>;
     using TransitionTableType = utils::StaticThisFunctor<void(const EventBaseType&, TransitionWrapperType&)>;
 
     using EntryFunctionType = utils::StaticThisFunctor<void(FSMInitContextType&)>;
+    using HandlerFunctionType = utils::StaticThisFunctor<void(FSMContextType&)>;
     using ExitFunctionType = utils::StaticThisFunctor<void()>;
 
     TransitionTableType transitions;
     EntryFunctionType entry{};
+    HandlerFunctionType handler{};
     ExitFunctionType exit{};
 
     // Callback should be set somehow from the context
     const StateIDType id;
-};
-
-template <typename ControllerType, typename EventBaseType, typename RepeatableType>
-class FSMContextImpl : public FSMContext<EventBaseType> {
-public:
-    FSMContextImpl(ControllerType& ctrl) : ctrl(ctrl){};
-    void set_callback(utils::StaticThisFunctor<void(FSMContext<EventBaseType>&)> fn, bool single_shot,
-                      int interval) override final {
-        cur_callback = fn;
-        state = single_shot ? InternalState::SingleCallbackQueued : InternalState::RecurringCallback;
-        this->interval = RepeatableType(interval);
-    }
-    bool submit_event(const EventBaseType& ev) override final {
-        return ctrl.submit_event(ev);
-    }
-    void cancel_callback() override final {
-        state = InternalState::NoCallback;
-    }
-    void repeat_callback() override final {
-        if (state == InternalState::NoCallback) {
-            return;
-        }
-    }
-
-    // interface for SyncController, checking the callback status and such ...
-
-    // FIXME (aw): ticks_to_next_run needs to be called before run() and the value must be passed
-    // although this is a private api, is it possible to make the api more fail-safe?
-    int ticks_to_next_run() {
-        if (state == InternalState::NoCallback || state == InternalState::SingleCallbackExeced) {
-            // there is nothing to do
-            return -1;
-        }
-
-        return interval.ticks_left();
-    }
-
-    bool run(int ticks_left) {
-        if (ticks_left != 0) {
-            return false;
-        }
-
-        // if we come here, we need to be in SingleCallbackQueued or RecurringCallback
-        // and the callback should be run
-        // NOTE (aw): this part is critical, because cur_callback might modify ourself
-        if (state == InternalState::SingleCallbackQueued) {
-            state = InternalState::SingleCallbackExeced;
-        } else { // must be RecurringCallback
-            interval.repeat_from_last();
-        }
-
-        cur_callback(*this);
-
-        return true;
-    }
-
-private:
-    enum class InternalState : uint8_t
-    {
-        NoCallback,
-        SingleCallbackQueued,
-        SingleCallbackExeced,
-        RecurringCallback
-    };
-
-    InternalState state{InternalState::NoCallback};
-
-    utils::StaticThisFunctor<void(FSMContext<EventBaseType>&)> cur_callback{};
-    bool single_shot{true};
-
-    RepeatableType interval;
-
-    // for submitting event
-    ControllerType& ctrl;
 };
 
 template <typename StateHandleType, typename RepeatableType, void (*LogFunction)(const std::string&) = nullptr>
@@ -126,7 +81,7 @@ class BasicController {
     using EventBaseType = typename StateHandleType::EventBaseType;
 
 public:
-    BasicController() : state_context(*this) {
+    BasicController() : state_context(*this), cur_trans(state_context) {
     }
     // setup starting state and call only the entry function, assuming
     // there will be no transitions setup during initial state
@@ -134,60 +89,102 @@ public:
     void reset(StateHandleType& initial_state) {
         log("Starting with state: " + initial_state.id.name);
         cur_state = &initial_state;
-        cur_state->entry(state_context);
+        if (cur_state->entry) {
+            cur_state->entry(state_context);
+        }
+        call_state = cur_state->handler ? HandlerCallState::InitialCallQueued : HandlerCallState::NoCall;
     }
 
     // returns the time in milliseconds, when this feed should be called again
     // if zero, it should be called immediately again
     // if negative, there is just nothing to do
     int feed() {
-        // run current callback if timer elapsed
-        int ticks_left = state_context.ticks_to_next_run();
-        if (state_context.run(ticks_left)) {
-            // in case the callback sent events
-            run_transitions();
-
-            return state_context.ticks_to_next_run();
+        switch (call_state) {
+        case HandlerCallState::NoCall:
+        case HandlerCallState::SingleCallDone:
+            return -1;
         }
 
-        return ticks_left;
+        // this needs to be SingleCallQueued or RecurringCall
+        // so we have to check for the timeout
+        auto ticks_left = call_timeout.ticks_left();
+        if (ticks_left != 0) {
+            return ticks_left;
+        }
+
+        if (call_state == HandlerCallState::SingleCallQueued) {
+            call_state = HandlerCallState::SingleCallDone;
+        } else {
+            // must be RecurringCallback
+            call_timeout.repeat_from_last();
+        }
+
+        cur_state->handler(state_context);
+
+        // if we end up here, a handler has been call and might
+        // triggered a new transition, therefor we need to check them
+
+        if (run_transition()) {
+            // now we have either NoCall because there
+            // is no handler, or we immediately need to run the initial
+            // handler
+            return (call_state == HandlerCallState::NoCall) ? -1 : 0;
+        }
+
+        // we call a handler but no transition, we only need to be called back again for the case, that we're in
+        if (call_state == HandlerCallState::SingleCallQueued || call_state == HandlerCallState::RecurringCall) {
+            return call_timeout.ticks_left();
+        }
+
+        return -1;
     }
 
     bool submit_event(const EventBaseType& event) {
         // check transition table of current set, return false if not possible
         cur_state->transitions(event, cur_trans);
 
-        return run_transitions();
+        return run_transition();
+    }
+
+    StateHandleType* current_state() {
+        return cur_state;
     }
 
 private:
     // return true, if at least one transition was done
-    bool run_transitions() {
+    bool run_transition() {
         if (!cur_trans) {
             return false;
         }
 
-        // while transition set?
-        // FIXME (aw): this might need rethinking, do we want to return during each transition?
-        while (cur_trans) {
-            const std::string old_state_name = cur_state->id.name;
-
-            // 1. run exit of current state
-            if (cur_state->exit) {
-                cur_state->exit();
-            }
-
-            // 2. run transition and set new state
-            cur_state = &cur_trans();
+        // handle "internal" transitions
+        if (cur_trans.is_internal()) {
+            // internal handler has been called already in the
+            // transitions block
+            log("Internal transition on " + cur_state->id.name);
             cur_trans.reset();
-
-            // 3. run entry of new state
-            if (cur_state->entry) {
-                cur_state->entry(state_context);
-            }
-
-            log("Went from " + old_state_name + " to " + cur_state->id.name);
+            return true;
         }
+
+        const std::string old_state_name = cur_state->id.name;
+
+        // 1. run exit of current state
+        if (cur_state->exit) {
+            cur_state->exit();
+        }
+
+        // 2. run transition and set new state
+        cur_state = &cur_trans();
+        cur_trans.reset();
+
+        // 3. run entry of new state
+        if (cur_state->entry) {
+            cur_state->entry(state_context);
+        }
+
+        call_state = (cur_state->handler) ? HandlerCallState::InitialCallQueued : HandlerCallState::NoCall;
+
+        log("Went from " + old_state_name + " to " + cur_state->id.name);
 
         return true;
     }
@@ -199,7 +196,51 @@ private:
         }
     }
 
-    FSMContextImpl<BasicController, EventBaseType, RepeatableType> state_context;
+    class FSMContextImpl : public FSMInitContext<EventBaseType>, public FSMContext<EventBaseType> {
+    public:
+        explicit FSMContextImpl(BasicController& ctrl) : ctrl(ctrl){};
+        void set_next_timeout(int interval, bool repeat) override final {
+            ctrl.call_timeout = RepeatableType(interval);
+            ctrl.call_state = repeat ? HandlerCallState::RecurringCall : HandlerCallState::SingleCallQueued;
+        }
+        bool submit_event(const EventBaseType& ev) override final {
+            auto& cur_trans = ctrl.cur_trans;
+            if (cur_trans && !cur_trans.is_internal()) {
+                ctrl.log("Recursive event submit detected!");
+            }
+
+            ctrl.cur_state->transitions(ev, cur_trans);
+            // FIXME (aw): should we disable calling set_next_timeout after submitting an event?
+            return cur_trans;
+        }
+
+        void disable_timeout() override final {
+            ctrl.call_state = HandlerCallState::NoCall;
+        }
+
+        void set_event_ptr(const EventBaseType* event_ptr) {
+            this->event = event_ptr;
+        }
+
+    private:
+        BasicController& ctrl;
+    };
+
+    RepeatableType call_timeout;
+
+    enum class HandlerCallState : uint8_t
+    {
+        NoCall,
+        InitialCallQueued,
+        InitialCallDone,
+        SingleCallQueued,
+        SingleCallDone,
+        RecurringCall
+    };
+
+    HandlerCallState call_state{HandlerCallState::NoCall};
+
+    FSMContextImpl state_context;
 
     StateHandleType* cur_state{nullptr};
     typename StateHandleType::TransitionWrapperType cur_trans;


### PR DESCRIPTION
- moved the previously called "callback" into a property, called
  handler, of the StateHandle
- supporting now "Internal" transitions, which should keep the state of
  the current state, instead of entry() it again
- removed the FSMInitContext for the entry() functions
- changed the running behaviour: at most one transition per
  submit_event() or feed(), feed() should be called immediately after a
  successful submit_event()
- fixed quite some bugs
- renamed CMake namespace from Fsm to fsm

Signed-off-by: aw <aw@pionix.de>